### PR TITLE
docs(README): correct minor spelling and grammar mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project contains language bindings required for loading and using the [DID resolver](https://github.com/swiyu-admin-ch/didresolver) library in Swift applications.
 
-You are more then welcome to explore the [relevant examples](https://github.com/swiyu-admin-ch/didresolver-examples) in a further detail.
+You are more than welcome to explore the [relevant examples](https://github.com/swiyu-admin-ch/didresolver-examples) in further detail.
 
 ## Contributions and feedback
 


### PR DESCRIPTION
Hi there 👋🏻 

While browsing the different repositories, I stumbled upon a minor grammatical error in the `README.md` of this project.

I appreciate your dedication to open source across the whole e-ID platform, bravo 👏🏻. Therefore, I went along and quickly fixed it for you. I surely believe you have more pressing topics in this tight schedule right now. Please don't hesitate to take a look at it whenever you like.

As a small aside: cloning the project takes quite long due to the statically bundled `libdidresolver.a` libraries ([here](https://github.com/swiyu-admin-ch/didresolver-swift/blob/c2d4808ad6ef5105e9d222ae495864089fa94cee/didresolver.xcframework/ios-arm64/libdidresolver.a) and [here](https://github.com/swiyu-admin-ch/didresolver-swift/blob/main/didresolver.xcframework/ios-arm64_x86_64-simulator/libdidresolver.a)). IMHO they should be dynamically downloaded when building the `didresolver-swift` library or at least stored in Git-LFS. Otherwise, the repo will become clumsy really fast when including the newly compiled library in each version bump.

Thank you for your work on the e-ID and have a great remaining week.

BR